### PR TITLE
fix(shulker-crds): use native default system whenever possible

### DIFF
--- a/kube/resources/crd/bases/shulkermc.io_minecraftserverfleets.yaml
+++ b/kube/resources/crd/bases/shulkermc.io_minecraftserverfleets.yaml
@@ -27,7 +27,7 @@ spec:
             spec:
               properties:
                 autoscaling:
-                  description: Autoscaling configuration for this `MinecraftServerFleet`.
+                  description: Autoscaling configuration for this `MinecraftServerFleet`
                   nullable: true
                   properties:
                     agonesPolicy:
@@ -365,8 +365,8 @@ spec:
                               default: Velocity
                               description: Type of forwarding the proxies are using between themselves and this `MinecraftServer`
                               enum:
-                                - BungeeCord
                                 - Velocity
+                                - BungeeCord
                               type: string
                             serverProperties:
                               additionalProperties:

--- a/kube/resources/crd/bases/shulkermc.io_minecraftservers.yaml
+++ b/kube/resources/crd/bases/shulkermc.io_minecraftservers.yaml
@@ -137,8 +137,8 @@ spec:
                       default: Velocity
                       description: Type of forwarding the proxies are using between themselves and this `MinecraftServer`
                       enum:
-                        - BungeeCord
                         - Velocity
+                        - BungeeCord
                       type: string
                     serverProperties:
                       additionalProperties:

--- a/kube/resources/crd/bases/shulkermc.io_proxyfleets.yaml
+++ b/kube/resources/crd/bases/shulkermc.io_proxyfleets.yaml
@@ -27,7 +27,7 @@ spec:
             spec:
               properties:
                 autoscaling:
-                  description: Autoscaling configuration for this `ProxyFleet`.
+                  description: Autoscaling configuration for this `ProxyFleet`
                   nullable: true
                   properties:
                     agonesPolicy:
@@ -128,10 +128,10 @@ spec:
                       nullable: true
                       type: object
                     externalTrafficPolicy:
-                      default: Cluster
                       enum:
                         - Cluster
                         - Local
+                      nullable: true
                       type: string
                     type:
                       default: LoadBalancer

--- a/packages/shulker-crds/src/v1alpha1/minecraft_server.rs
+++ b/packages/shulker-crds/src/v1alpha1/minecraft_server.rs
@@ -4,7 +4,7 @@ use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;
 use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use strum::IntoStaticStr;
+use strum::{Display, IntoStaticStr};
 
 use super::minecraft_cluster::MinecraftClusterRef;
 
@@ -39,6 +39,7 @@ pub struct MinecraftServerSpec {
 
     /// Overrides for values to be injected in the created `Pod`
     /// of this `MinecraftServer`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub pod_overrides: Option<MinecraftServerPodOverridesSpec>,
 }
 
@@ -46,35 +47,16 @@ pub struct MinecraftServerSpec {
 #[serde(rename_all = "camelCase")]
 pub struct MinecraftServerVersionSpec {
     /// Channel of the version to use. Defaults to Paper
-    #[schemars(default = "MinecraftServerVersionSpec::default_channel")]
-    #[schemars(schema_with = "MinecraftServerVersionSpec::schema_channel")]
+    #[serde(default)]
     pub channel: MinecraftServerVersion,
 
     /// Name of the version to use
     pub name: String,
 }
 
-#[cfg(not(tarpaulin_include))]
-impl MinecraftServerVersionSpec {
-    fn default_channel() -> MinecraftServerVersion {
-        MinecraftServerVersion::Paper
-    }
-
-    fn schema_channel(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        schemars::schema::SchemaObject {
-            instance_type: Some(schemars::schema::InstanceType::String.into()),
-            enum_values: Some(vec![
-                serde_json::Value::String("Paper".to_string()),
-                serde_json::Value::String("Bukkit".to_string()),
-                serde_json::Value::String("Spigot".to_string()),
-            ]),
-            ..Default::default()
-        }
-        .into()
-    }
-}
-
-#[derive(PartialEq, Deserialize, Serialize, Clone, Debug, Default, IntoStaticStr)]
+#[derive(
+    PartialEq, Deserialize, Serialize, Clone, Debug, Default, JsonSchema, IntoStaticStr, Display,
+)]
 pub enum MinecraftServerVersion {
     #[default]
     Paper,
@@ -87,17 +69,21 @@ pub enum MinecraftServerVersion {
 pub struct MinecraftServerConfigurationSpec {
     /// Name of an optional ConfigMap already containing the server
     /// configuration
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub existing_config_map_name: Option<String>,
 
     /// Reference to a world to download and extract. Gzipped tarball
     /// only
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub world: Option<ResourceRefSpec>,
 
     /// List of references to plugins to download
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub plugins: Option<Vec<ResourceRefSpec>>,
 
     /// List of optional references to patch archives to download
     /// and extract at the root of the server. Gzippied tarballs only
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub patches: Option<Vec<ResourceRefSpec>>,
 
     /// Number of maximum players that can connect to the
@@ -122,8 +108,7 @@ pub struct MinecraftServerConfigurationSpec {
 
     /// Type of forwarding the proxies are using between themselves and
     /// this `MinecraftServer`
-    #[schemars(default = "MinecraftServerConfigurationSpec::default_proxy_forwarding_mode")]
-    #[schemars(schema_with = "MinecraftServerConfigurationSpec::schema_proxy_forwarding_mode")]
+    #[serde(default)]
     pub proxy_forwarding_mode: MinecraftServerConfigurationProxyForwardingMode,
 }
 
@@ -140,27 +125,11 @@ impl MinecraftServerConfigurationSpec {
     fn default_disable_end() -> bool {
         true
     }
-
-    fn default_proxy_forwarding_mode() -> MinecraftServerConfigurationProxyForwardingMode {
-        MinecraftServerConfigurationProxyForwardingMode::Velocity
-    }
-
-    fn schema_proxy_forwarding_mode(
-        _: &mut schemars::gen::SchemaGenerator,
-    ) -> schemars::schema::Schema {
-        schemars::schema::SchemaObject {
-            instance_type: Some(schemars::schema::InstanceType::String.into()),
-            enum_values: Some(vec![
-                serde_json::Value::String("Velocity".to_string()),
-                serde_json::Value::String("BungeeCord".to_string()),
-            ]),
-            ..Default::default()
-        }
-        .into()
-    }
 }
 
-#[derive(PartialEq, Deserialize, Serialize, Clone, Debug, Default, IntoStaticStr)]
+#[derive(
+    PartialEq, Deserialize, Serialize, Clone, Debug, Default, JsonSchema, IntoStaticStr, Display,
+)]
 pub enum MinecraftServerConfigurationProxyForwardingMode {
     #[default]
     Velocity,
@@ -171,24 +140,31 @@ pub enum MinecraftServerConfigurationProxyForwardingMode {
 #[serde(rename_all = "camelCase")]
 pub struct MinecraftServerPodOverridesSpec {
     /// Image to use as replacement for the built-in one
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub image: Option<ImageOverrideSpec>,
 
     /// Extra environment variables to add to the crated `Pod`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub env: Option<Vec<k8s_openapi::api::core::v1::EnvVar>>,
 
     /// The desired compute resource requirements of the created `Pod`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub resources: Option<k8s_openapi::api::core::v1::ResourceRequirements>,
 
     /// Affinity scheduling rules to be applied on created `Pod`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub affinity: Option<k8s_openapi::api::core::v1::Affinity>,
 
     /// Node selector to be applied on created `Pod`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub node_selector: Option<HashMap<String, String>>,
 
     /// Tolerations to be applied on created `Pod`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tolerations: Option<Vec<k8s_openapi::api::core::v1::Toleration>>,
 
     /// Name of the ServiceAccount to use
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub service_account_name: Option<String>,
 }
 

--- a/packages/shulker-crds/src/v1alpha1/minecraft_server_fleet.rs
+++ b/packages/shulker-crds/src/v1alpha1/minecraft_server_fleet.rs
@@ -32,7 +32,8 @@ pub struct MinecraftServerFleetSpec {
     /// Describe how to create the underlying `MinecraftServers`
     pub template: TemplateSpec<MinecraftServerSpec>,
 
-    /// Autoscaling configuration for this `MinecraftServerFleet`.
+    /// Autoscaling configuration for this `MinecraftServerFleet`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub autoscaling: Option<FleetAutoscalingSpec>,
 }
 

--- a/packages/shulker-crds/src/v1alpha1/proxy_fleet.rs
+++ b/packages/shulker-crds/src/v1alpha1/proxy_fleet.rs
@@ -38,9 +38,11 @@ pub struct ProxyFleetSpec {
 
     /// The desired state of the Kubernetes `Service` to create for the
     /// Proxy Deployment
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub service: Option<ProxyFleetServiceSpec>,
 
-    /// Autoscaling configuration for this `ProxyFleet`.
+    /// Autoscaling configuration for this `ProxyFleet`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub autoscaling: Option<FleetAutoscalingSpec>,
 }
 
@@ -64,6 +66,7 @@ pub struct ProxyFleetTemplateSpec {
 
     /// Overrides for values to be injected in the created `Pod`
     /// of this `ProxyFleet`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub pod_overrides: Option<ProxyFleetTemplatePodOverridesSpec>,
 }
 
@@ -71,35 +74,16 @@ pub struct ProxyFleetTemplateSpec {
 #[serde(rename_all = "camelCase")]
 pub struct ProxyFleetTemplateVersionSpec {
     /// Channel of the version to use. Defaults to Velocity
-    #[schemars(default = "ProxyFleetTemplateVersionSpec::default_channel")]
-    #[schemars(schema_with = "ProxyFleetTemplateVersionSpec::schema_channel")]
+    #[serde(default)]
     pub channel: ProxyFleetTemplateVersion,
 
     /// Name of the version to use
     pub name: String,
 }
 
-#[cfg(not(tarpaulin_include))]
-impl ProxyFleetTemplateVersionSpec {
-    fn default_channel() -> ProxyFleetTemplateVersion {
-        ProxyFleetTemplateVersion::Velocity
-    }
-
-    fn schema_channel(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        schemars::schema::SchemaObject {
-            instance_type: Some(schemars::schema::InstanceType::String.into()),
-            enum_values: Some(vec![
-                serde_json::Value::String("Velocity".to_string()),
-                serde_json::Value::String("BungeeCord".to_string()),
-                serde_json::Value::String("Waterfall".to_string()),
-            ]),
-            ..Default::default()
-        }
-        .into()
-    }
-}
-
-#[derive(PartialEq, Deserialize, Serialize, Clone, Debug, Default, IntoStaticStr)]
+#[derive(
+    PartialEq, Deserialize, Serialize, Clone, Debug, Default, JsonSchema, IntoStaticStr, Display,
+)]
 pub enum ProxyFleetTemplateVersion {
     #[default]
     Velocity,
@@ -112,13 +96,16 @@ pub enum ProxyFleetTemplateVersion {
 pub struct ProxyFleetTemplateConfigurationSpec {
     /// Name of an optional ConfigMap already containing the proxy
     /// configuration
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub existing_config_map_name: Option<String>,
 
     /// List of references to plugins to download
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub plugins: Option<Vec<ResourceRefSpec>>,
 
     /// List of optional references to patch archives to download
     /// and extract at the root of the proxy. Gzippied tarballs only
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub patches: Option<Vec<ResourceRefSpec>>,
 
     /// Number of maximum players that can connect to the
@@ -172,24 +159,31 @@ impl ProxyFleetTemplateConfigurationSpec {
 #[serde(rename_all = "camelCase")]
 pub struct ProxyFleetTemplatePodOverridesSpec {
     /// Image to use as replacement for the built-in one
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub image: Option<ImageOverrideSpec>,
 
     /// Extra environment variables to add to the crated `Pod`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub env: Option<Vec<k8s_openapi::api::core::v1::EnvVar>>,
 
     /// The desired compute resource requirements of the created `Pod`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub resources: Option<k8s_openapi::api::core::v1::ResourceRequirements>,
 
     /// Affinity scheduling rules to be applied on created `Pod`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub affinity: Option<k8s_openapi::api::core::v1::Affinity>,
 
     /// Node selector to be applied on created `Pod`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub node_selector: Option<HashMap<String, String>>,
 
     /// Tolerations to be applied on created `Pod`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tolerations: Option<Vec<k8s_openapi::api::core::v1::Toleration>>,
 
     /// Name of the ServiceAccount to use
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub service_account_name: Option<String>,
 }
 
@@ -198,58 +192,22 @@ pub struct ProxyFleetTemplatePodOverridesSpec {
 pub struct ProxyFleetServiceSpec {
     /// Type of Service to create.
     /// Must be one of: ClusterIP, LoadBalancer, NodePort
-    #[schemars(default = "ProxyFleetServiceSpec::default_type")]
-    #[schemars(schema_with = "ProxyFleetServiceSpec::schema_type")]
+    #[serde(default)]
     pub type_: ProxyFleetServiceType,
 
     // Annotations to add to the `Service`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<BTreeMap<String, String>>,
 
     // Describe how nodes distribute service traffic to the proxy.
-    #[schemars(default = "ProxyFleetServiceSpec::default_external_traffic_policy")]
-    #[schemars(schema_with = "ProxyFleetServiceSpec::schema_external_traffic_policy")]
-    pub external_traffic_policy: ProxyFleetServiceExternalTrafficPolicy,
+    // #[schemars(schema_with = "ProxyFleetServiceSpec::schema_external_traffic_policy")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub external_traffic_policy: Option<ProxyFleetServiceExternalTrafficPolicy>,
 }
 
-#[cfg(not(tarpaulin_include))]
-impl ProxyFleetServiceSpec {
-    fn default_type() -> ProxyFleetServiceType {
-        ProxyFleetServiceType::LoadBalancer
-    }
-
-    fn schema_type(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        schemars::schema::SchemaObject {
-            instance_type: Some(schemars::schema::InstanceType::String.into()),
-            enum_values: Some(vec![
-                serde_json::Value::String("ClusterIP".to_string()),
-                serde_json::Value::String("NodePort".to_string()),
-                serde_json::Value::String("LoadBalancer".to_string()),
-            ]),
-            ..Default::default()
-        }
-        .into()
-    }
-
-    fn default_external_traffic_policy() -> ProxyFleetServiceExternalTrafficPolicy {
-        ProxyFleetServiceExternalTrafficPolicy::Cluster
-    }
-
-    fn schema_external_traffic_policy(
-        _: &mut schemars::gen::SchemaGenerator,
-    ) -> schemars::schema::Schema {
-        schemars::schema::SchemaObject {
-            instance_type: Some(schemars::schema::InstanceType::String.into()),
-            enum_values: Some(vec![
-                serde_json::Value::String("Cluster".to_string()),
-                serde_json::Value::String("Local".to_string()),
-            ]),
-            ..Default::default()
-        }
-        .into()
-    }
-}
-
-#[derive(PartialEq, Deserialize, Serialize, Clone, Debug, Default, IntoStaticStr, Display)]
+#[derive(
+    PartialEq, Deserialize, Serialize, Clone, Debug, Default, JsonSchema, IntoStaticStr, Display,
+)]
 pub enum ProxyFleetServiceType {
     ClusterIP,
     NodePort,
@@ -257,10 +215,12 @@ pub enum ProxyFleetServiceType {
     LoadBalancer,
 }
 
-#[derive(PartialEq, Deserialize, Serialize, Clone, Debug, Default, IntoStaticStr, Display)]
+#[derive(
+    PartialEq, Deserialize, Serialize, Clone, Debug, Default, JsonSchema, IntoStaticStr, Display,
+)]
 pub enum ProxyFleetServiceExternalTrafficPolicy {
-    #[default]
     Cluster,
+    #[default]
     Local,
 }
 

--- a/packages/shulker-operator/src/reconcilers/proxy_fleet/service.rs
+++ b/packages/shulker-operator/src/reconcilers/proxy_fleet/service.rs
@@ -76,7 +76,10 @@ impl ResourceBuilder for ServiceBuilder {
                     .collect(),
             ),
             type_: Some(service_config.type_.to_string()),
-            external_traffic_policy: Some(service_config.external_traffic_policy.to_string()),
+            external_traffic_policy: service_config
+                .external_traffic_policy
+                .as_ref()
+                .map(|x| x.to_string()),
             ports: Some(vec![ServicePort {
                 name: Some("minecraft".to_string()),
                 protocol: Some("TCP".to_string()),


### PR DESCRIPTION
Rework CRD schemas involving enums to properly have optional & default values. Also, add an `externalTrafficPolicy` field to a `Service` only when filled.

Closes #152