### PR TITLE
fix(shulker-operator): do not let Agones map the server ports

### DIFF
--- a/packages/shulker-operator/src/reconcilers/minecraft_server/gameserver.rs
+++ b/packages/shulker-operator/src/reconcilers/minecraft_server/gameserver.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use k8s_openapi::api::core::v1::Capabilities;
 use k8s_openapi::api::core::v1::ConfigMapVolumeSource;
 use k8s_openapi::api::core::v1::Container;
+use k8s_openapi::api::core::v1::ContainerPort;
 use k8s_openapi::api::core::v1::EmptyDirVolumeSource;
 use k8s_openapi::api::core::v1::EnvVar;
 use k8s_openapi::api::core::v1::EnvVarSource;
@@ -29,7 +30,6 @@ use crate::resources::resourceref_resolver::ResourceRefResolver;
 use google_agones_crds::v1::game_server::GameServer;
 use google_agones_crds::v1::game_server::GameServerEvictionSpec;
 use google_agones_crds::v1::game_server::GameServerHealthSpec;
-use google_agones_crds::v1::game_server::GameServerPortSpec;
 use google_agones_crds::v1::game_server::GameServerSpec;
 use shulker_crds::v1alpha1::minecraft_server::MinecraftServer;
 use shulker_kube_utils::reconcilers::builder::ResourceBuilder;
@@ -136,11 +136,7 @@ impl<'a> GameServerBuilder {
             Self::get_pod_template_spec(resourceref_resolver, context, minecraft_server).await?;
 
         let game_server_spec = GameServerSpec {
-            ports: Some(vec![GameServerPortSpec {
-                name: "minecraft".to_string(),
-                container_port: 25565,
-                protocol: "TCP".to_string(),
-            }]),
+            ports: None,
             eviction: Some(GameServerEvictionSpec {
                 safe: "OnUpgrade".to_string(),
             }),
@@ -194,6 +190,12 @@ impl<'a> GameServerBuilder {
                 env: Some(Self::get_env(resourceref_resolver, context, minecraft_server).await?),
                 image_pull_policy: Some("IfNotPresent".to_string()),
                 security_context: Some(PROXY_SECURITY_CONTEXT.clone()),
+                ports: Some(vec![ContainerPort {
+                    name: Some("minecraft".to_string()),
+                    container_port: 25565,
+                    protocol: Some("TCP".to_string()),
+                    ..ContainerPort::default()
+                }]),
                 volume_mounts: Some(vec![
                     VolumeMount {
                         name: "server-config".to_string(),

--- a/packages/shulker-operator/src/reconcilers/minecraft_server/snapshots/shulker_operator__reconcilers__minecraft_server__gameserver__tests__build_snapshot.snap
+++ b/packages/shulker-operator/src/reconcilers/minecraft_server/snapshots/shulker_operator__reconcilers__minecraft_server__gameserver__tests__build_snapshot.snap
@@ -17,10 +17,6 @@ metadata:
   name: my-server
   namespace: default
 spec:
-  ports:
-    - name: minecraft
-      containerPort: 25565
-      protocol: TCP
   health:
     disabled: false
     periodSeconds: 15
@@ -80,6 +76,10 @@ spec:
           image: "itzg/minecraft-server:2023.10.1-java17"
           imagePullPolicy: IfNotPresent
           name: minecraft-server
+          ports:
+            - containerPort: 25565
+              name: minecraft
+              protocol: TCP
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/packages/shulker-operator/src/reconcilers/minecraft_server_fleet/snapshots/shulker_operator__reconcilers__minecraft_server_fleet__fleet__tests__build_snapshot.snap
+++ b/packages/shulker-operator/src/reconcilers/minecraft_server_fleet/snapshots/shulker_operator__reconcilers__minecraft_server_fleet__fleet__tests__build_snapshot.snap
@@ -35,10 +35,6 @@ spec:
         minecraftserverfleet.shulkermc.io/name: my-server
         test-label/shulkermc.io: my-value
     spec:
-      ports:
-        - name: minecraft
-          containerPort: 25565
-          protocol: TCP
       health:
         disabled: false
         periodSeconds: 15
@@ -102,6 +98,10 @@ spec:
               image: "itzg/minecraft-server:2023.10.1-java17"
               imagePullPolicy: IfNotPresent
               name: minecraft-server
+              ports:
+                - containerPort: 25565
+                  name: minecraft
+                  protocol: TCP
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:


### PR DESCRIPTION
When Agones maps the ports of the GameServer, it also binds a host port. It's not something we want for the servers as the network is routed through the proxies, so internally of the Kubernetes cluster.