### PR TITLE
docs: change "Mounting volumes" example text

### DIFF
--- a/docs/src/latest/guide/recipes/overriding-pod-properties.md
+++ b/docs/src/latest/guide/recipes/overriding-pod-properties.md
@@ -89,10 +89,10 @@ spec:
     name: my-cluster
   podOverrides: // [!code focus]
     volumeMounts: // [!code focus]
-      - name: my_extra_volume // [!code focus]
+      - name: my-extra-volume // [!code focus]
         mountPath: /mnt/path // [!code focus]
     volumes: // [!code focus]
-      - name: my_extra_volume // [!code focus]
+      - name: my-extra-volume // [!code focus]
         emptyDir: {} // [!code focus]
 ```
 

--- a/docs/src/next/guide/recipes/overriding-pod-properties.md
+++ b/docs/src/next/guide/recipes/overriding-pod-properties.md
@@ -89,10 +89,10 @@ spec:
     name: my-cluster
   podOverrides: // [!code focus]
     volumeMounts: // [!code focus]
-      - name: my_extra_volume // [!code focus]
+      - name: my-extra-volume // [!code focus]
         mountPath: /mnt/path // [!code focus]
     volumes: // [!code focus]
-      - name: my_extra_volume // [!code focus]
+      - name: my-extra-volume // [!code focus]
         emptyDir: {} // [!code focus]
 ```
 


### PR DESCRIPTION
Kubernetes does not like it when you use underscores (_) in value names, and fails when using the example text from this tutorial. Changing to a dash makes it so that a user may apply this change without renaming it.