### PR TITLE
docs: fix Mincraft typo

### DIFF
--- a/docs/src/latest/guide/getting-started/your-first-cluster.md
+++ b/docs/src/latest/guide/getting-started/your-first-cluster.md
@@ -18,7 +18,7 @@ the namespace.
 
 ## A _spoon_ of MinecraftCluster
 
-Everything starts by creating a `MincraftCluster`. As described in
+Everything starts by creating a `MinecraftCluster`. As described in
 the **[Architecture](../architecture)** chapter, it is the most important
 entity because it is referenced in many other resources.
 

--- a/docs/src/next/guide/getting-started/your-first-cluster.md
+++ b/docs/src/next/guide/getting-started/your-first-cluster.md
@@ -18,7 +18,7 @@ the namespace.
 
 ## A _spoon_ of MinecraftCluster
 
-Everything starts by creating a `MincraftCluster`. As described in
+Everything starts by creating a `MinecraftCluster`. As described in
 the **[Architecture](../architecture)** chapter, it is the most important
 entity because it is referenced in many other resources.
 


### PR DESCRIPTION
Fixes typo in section "A Spoon of MinecraftCluster." "Min"craft to Minecraft