### PR TITLE
docs: add search

### DIFF
--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -105,6 +105,10 @@ export default defineConfig({
       },
     ],
 
+    search: {
+      provider: 'local'
+    }
+
     sidebar: versions.sidebars,
   },
 });

--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -106,8 +106,8 @@ export default defineConfig({
     ],
 
     search: {
-      provider: 'local'
-    }
+      provider: 'local',
+    },
 
     sidebar: versions.sidebars,
   },


### PR DESCRIPTION
Implemented request 6 from #435:

> Implementing a search feature on the documentation site to allow users to easily find the information they are looking for. This would improve the user experience by making the documentation more accessible and navigable.

This was easy to add since VitePress already contains search functionality, the "local" provider is the most easiest to set up *as it requires adding 3 lines to the VitePress config*.