### PR TITLE
fix(shulker-proxy-agent): crash when LoadBalancer service does not have any ingress in status

### DIFF
--- a/packages/shulker-operator/src/reconcilers/minecraft_cluster/proxy_role.rs
+++ b/packages/shulker-operator/src/reconcilers/minecraft_cluster/proxy_role.rs
@@ -60,7 +60,7 @@ impl<'a> ResourceBuilder<'a> for ProxyRoleBuilder {
                 PolicyRule {
                     api_groups: Some(vec!["".to_string()]),
                     resources: Some(vec!["services".to_string()]),
-                    verbs: vec!["get".to_string()],
+                    verbs: vec!["get".to_string(), "watch".to_string()],
                     ..PolicyRule::default()
                 },
                 PolicyRule {

--- a/packages/shulker-operator/src/reconcilers/minecraft_cluster/snapshots/shulker_operator__reconcilers__minecraft_cluster__proxy_role__tests__build_snapshot.snap
+++ b/packages/shulker-operator/src/reconcilers/minecraft_cluster/snapshots/shulker_operator__reconcilers__minecraft_cluster__proxy_role__tests__build_snapshot.snap
@@ -30,6 +30,7 @@ rules:
       - services
     verbs:
       - get
+      - watch
   - apiGroups:
       - ""
     resources:

--- a/packages/shulker-proxy-agent/src/common/kotlin/io/shulkermc/proxyagent/adapters/kubernetes/ImplKubernetesGatewayAdapter.kt
+++ b/packages/shulker-proxy-agent/src/common/kotlin/io/shulkermc/proxyagent/adapters/kubernetes/ImplKubernetesGatewayAdapter.kt
@@ -16,6 +16,7 @@ class ImplKubernetesGatewayAdapter(proxyNamespace: String, proxyName: String) : 
     companion object {
         private const val PROXY_INFORMER_SYNC_MS = 30L * 1000
         private const val SERVER_INFORMER_SYNC_MS = 10L * 1000
+        private const val MINECRAFT_DEFAULT_PORT = 25565
     }
 
     private val kubernetesClient: KubernetesClient =
@@ -63,12 +64,8 @@ class ImplKubernetesGatewayAdapter(proxyNamespace: String, proxyName: String) : 
             return Optional.empty()
         }
 
-        return try {
-            val ingress = service.status.loadBalancer.ingress[0]
-            Optional.of(InetSocketAddress(ingress.ip, ingress.ports[0].port))
-        } catch (_: NullPointerException) {
-            Optional.empty()
-        }
+        return Optional.ofNullable(service.status.loadBalancer?.ingress?.firstOrNull())
+            .map { ingress -> InetSocketAddress(ingress.ip, MINECRAFT_DEFAULT_PORT) }
     }
 
     override fun watchProxyEvents(

--- a/packages/shulker-proxy-agent/src/common/kotlin/io/shulkermc/proxyagent/adapters/kubernetes/ImplKubernetesGatewayAdapter.kt
+++ b/packages/shulker-proxy-agent/src/common/kotlin/io/shulkermc/proxyagent/adapters/kubernetes/ImplKubernetesGatewayAdapter.kt
@@ -2,9 +2,11 @@ package io.shulkermc.proxyagent.adapters.kubernetes
 
 import io.fabric8.kubernetes.api.model.ObjectReference
 import io.fabric8.kubernetes.api.model.ObjectReferenceBuilder
+import io.fabric8.kubernetes.api.model.Service
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.fabric8.kubernetes.client.KubernetesClientBuilder
 import io.fabric8.kubernetes.client.informers.ResourceEventHandler
+import io.fabric8.kubernetes.client.informers.SharedIndexInformer
 import io.fabric8.kubernetes.client.okhttp.OkHttpClientFactory
 import io.shulkermc.proxyagent.Configuration
 import io.shulkermc.proxyagent.adapters.kubernetes.models.AgonesV1GameServer
@@ -16,6 +18,7 @@ class ImplKubernetesGatewayAdapter(proxyNamespace: String, proxyName: String) : 
     companion object {
         private const val PROXY_INFORMER_SYNC_MS = 30L * 1000
         private const val SERVER_INFORMER_SYNC_MS = 10L * 1000
+        private const val SERVICE_INFORMER_SYNC_MS = 30L * 1000
         private const val MINECRAFT_DEFAULT_PORT = 25565
     }
 
@@ -49,23 +52,13 @@ class ImplKubernetesGatewayAdapter(proxyNamespace: String, proxyName: String) : 
         ).list()
     }
 
-    override fun getFleetServiceAddress(): Optional<InetSocketAddress> {
-        if (Configuration.PROXY_PREFERRED_RECONNECT_ADDRESS.isPresent) {
-            return Configuration.PROXY_PREFERRED_RECONNECT_ADDRESS
-        }
-
-        val service =
+    override fun getExternalAddress(): Optional<InetSocketAddress> {
+        return this.getExternalAddressFromService(
             this.kubernetesClient.services()
                 .inNamespace(Configuration.PROXY_NAMESPACE)
                 .withName(Configuration.PROXY_FLEET_NAME)
-                .get()
-
-        if (service.spec.type != "LoadBalancer") {
-            return Optional.empty()
-        }
-
-        return Optional.ofNullable(service.status.loadBalancer?.ingress?.firstOrNull())
-            .map { ingress -> InetSocketAddress(ingress.ip, MINECRAFT_DEFAULT_PORT) }
+                .get(),
+        )
     }
 
     override fun watchProxyEvents(
@@ -78,14 +71,7 @@ class ImplKubernetesGatewayAdapter(proxyNamespace: String, proxyName: String) : 
                 .withLabel("app.kubernetes.io/component", "proxy")
                 .inform(eventHandler, PROXY_INFORMER_SYNC_MS)
 
-        return proxyInformer.start()
-            .thenApply {
-                object : KubernetesGatewayAdapter.EventWatcher {
-                    override fun stop() {
-                        proxyInformer.stop()
-                    }
-                }
-            }
+        return this.createEventWatcher(proxyInformer)
     }
 
     override fun watchMinecraftServerEvents(
@@ -98,12 +84,32 @@ class ImplKubernetesGatewayAdapter(proxyNamespace: String, proxyName: String) : 
                 .withLabel("app.kubernetes.io/component", "minecraft-server")
                 .inform(eventHandler, SERVER_INFORMER_SYNC_MS)
 
-        return minecraftServerInformer.start().thenApply {
-            object : KubernetesGatewayAdapter.EventWatcher {
-                override fun stop() {
-                    minecraftServerInformer.stop()
-                }
+        return this.createEventWatcher(minecraftServerInformer)
+    }
+
+    override fun watchExternalAddressUpdates(
+        callback: (address: Optional<InetSocketAddress>) -> Unit,
+    ): CompletionStage<KubernetesGatewayAdapter.EventWatcher> {
+        val eventHandler =
+            this.createEventHandler<Service> { _, service ->
+                callback(this.getExternalAddressFromService(service))
             }
+
+        val serviceInformer =
+            this.kubernetesClient.services()
+                .inNamespace(Configuration.PROXY_NAMESPACE)
+                .withName(Configuration.PROXY_FLEET_NAME)
+                .inform(eventHandler, SERVICE_INFORMER_SYNC_MS)
+
+        return this.createEventWatcher(serviceInformer)
+    }
+
+    private fun getExternalAddressFromService(service: Service): Optional<InetSocketAddress> {
+        return if (service.spec.type == "LoadBalancer") {
+            Optional.ofNullable(service.status.loadBalancer?.ingress?.firstOrNull())
+                .map { ingress -> InetSocketAddress(ingress.ip, MINECRAFT_DEFAULT_PORT) }
+        } else {
+            Optional.empty()
         }
     }
 
@@ -125,6 +131,16 @@ class ImplKubernetesGatewayAdapter(proxyNamespace: String, proxyName: String) : 
                 deletedFinalStateUnknown: Boolean,
             ) {
                 callback(WatchAction.DELETED, obj)
+            }
+        }
+    }
+
+    private fun <T> createEventWatcher(informer: SharedIndexInformer<T>): CompletionStage<KubernetesGatewayAdapter.EventWatcher> {
+        return informer.start().thenApply {
+            object : KubernetesGatewayAdapter.EventWatcher {
+                override fun stop() {
+                    informer.stop()
+                }
             }
         }
     }

--- a/packages/shulker-proxy-agent/src/common/kotlin/io/shulkermc/proxyagent/adapters/kubernetes/KubernetesGatewayAdapter.kt
+++ b/packages/shulker-proxy-agent/src/common/kotlin/io/shulkermc/proxyagent/adapters/kubernetes/KubernetesGatewayAdapter.kt
@@ -16,7 +16,7 @@ interface KubernetesGatewayAdapter {
 
     fun listMinecraftServers(): AgonesV1GameServer.List
 
-    fun getFleetServiceAddress(): Optional<InetSocketAddress>
+    fun getExternalAddress(): Optional<InetSocketAddress>
 
     fun watchProxyEvents(
         callback: (action: WatchAction, proxy: AgonesV1GameServer) -> Unit,
@@ -24,6 +24,10 @@ interface KubernetesGatewayAdapter {
 
     fun watchMinecraftServerEvents(
         callback: (action: WatchAction, minecraftServer: AgonesV1GameServer) -> Unit,
+    ): CompletionStage<EventWatcher>
+
+    fun watchExternalAddressUpdates(
+        callback: (address: Optional<InetSocketAddress>) -> Unit,
     ): CompletionStage<EventWatcher>
 
     interface EventWatcher {


### PR DESCRIPTION
Also, now watch the Service's updates, so the external IP is updated directly without any restart.

Closes #626 