### PR TITLE
feat: support providing external servers

### DIFF
--- a/kube/helm/templates/crds/shulkermc.io_minecraftclusters.yaml
+++ b/kube/helm/templates/crds/shulkermc.io_minecraftclusters.yaml
@@ -23,6 +23,28 @@ spec:
         properties:
           spec:
             properties:
+              externalServers:
+                description: List of servers that should be registered on the proxies that are not managed by Shulker
+                items:
+                  properties:
+                    address:
+                      description: Address of the server, may contain a port after a colon
+                      type: string
+                    name:
+                      description: Name of the server, as the proxies will register it. Allowed names only are lowercased, dash-separated alphanumerical string
+                      pattern: ^[a-z0-9\-]+$
+                      type: string
+                    tags:
+                      description: Tags associated to the server
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - address
+                  - name
+                  type: object
+                nullable: true
+                type: array
               networkAdmins:
                 description: List of player UUIDs that are automatically promoted as network administrators, which are granted all the permissions by default on all the proxies and servers
                 items:

--- a/packages/shulker-crds/src/v1alpha1/minecraft_cluster.rs
+++ b/packages/shulker-crds/src/v1alpha1/minecraft_cluster.rs
@@ -24,6 +24,11 @@ pub struct MinecraftClusterSpec {
     /// for the different Shulker components
     #[serde(skip_serializing_if = "Option::is_none")]
     pub redis: Option<MinecraftClusterRedisSpec>,
+
+    /// List of servers that should be registered on the proxies
+    /// that are not managed by Shulker
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub external_servers: Option<Vec<MinecraftClusterExternalServerSpec>>,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
@@ -70,6 +75,23 @@ impl MinecraftClusterRedisProvidedSpec {
     fn default_port() -> u16 {
         6379
     }
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MinecraftClusterExternalServerSpec {
+    /// Name of the server, as the proxies will register it.
+    /// Allowed names only are lowercased, dash-separated
+    /// alphanumerical string
+    #[schemars(regex(pattern = r"^[a-z0-9\-]+$"))]
+    pub name: String,
+
+    /// Address of the server, may contain a port after a colon
+    pub address: String,
+
+    /// Tags associated to the server
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
 }
 
 /// The status object of `MinecraftCluster`

--- a/packages/shulker-operator/src/reconcilers/minecraft_cluster/external_servers_config_map.rs
+++ b/packages/shulker-operator/src/reconcilers/minecraft_cluster/external_servers_config_map.rs
@@ -1,0 +1,110 @@
+use std::collections::BTreeMap;
+
+use k8s_openapi::api::core::v1::ConfigMap;
+use kube::core::ObjectMeta;
+use kube::Api;
+use kube::Client;
+use kube::ResourceExt;
+
+use shulker_crds::v1alpha1::minecraft_cluster::MinecraftCluster;
+use shulker_kube_utils::reconcilers::builder::ResourceBuilder;
+
+use super::MinecraftClusterReconciler;
+
+pub struct ExternalServersConfigMapBuilder {
+    client: Client,
+}
+
+#[async_trait::async_trait]
+impl<'a> ResourceBuilder<'a> for ExternalServersConfigMapBuilder {
+    type OwnerType = MinecraftCluster;
+    type ResourceType = ConfigMap;
+    type Context = ();
+
+    fn name(cluster: &Self::OwnerType) -> String {
+        format!("{}-external-servers", cluster.name_any())
+    }
+
+    fn api(&self, cluster: &Self::OwnerType) -> kube::Api<Self::ResourceType> {
+        Api::namespaced(self.client.clone(), cluster.namespace().as_ref().unwrap())
+    }
+
+    fn is_needed(&self, cluster: &Self::OwnerType) -> bool {
+        cluster
+            .spec
+            .external_servers
+            .as_ref()
+            .map_or(false, |list| !list.is_empty())
+    }
+
+    async fn build(
+        &self,
+        cluster: &Self::OwnerType,
+        name: &str,
+        _existing_config_map: Option<&Self::ResourceType>,
+        _context: Option<Self::Context>,
+    ) -> Result<Self::ResourceType, anyhow::Error> {
+        let config_map = ConfigMap {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(cluster.namespace().unwrap().clone()),
+                labels: Some(MinecraftClusterReconciler::get_labels(
+                    cluster,
+                    "external-servers".to_string(),
+                    "proxy".to_string(),
+                )),
+                ..ObjectMeta::default()
+            },
+            data: Some(BTreeMap::from([(
+                "external-servers.yaml".to_string(),
+                ExternalServersConfigMapBuilder::get_content_from_server_list(cluster),
+            )])),
+            ..ConfigMap::default()
+        };
+
+        Ok(config_map)
+    }
+}
+
+impl ExternalServersConfigMapBuilder {
+    pub fn new(client: Client) -> Self {
+        ExternalServersConfigMapBuilder { client }
+    }
+
+    fn get_content_from_server_list(cluster: &MinecraftCluster) -> String {
+        serde_yaml::to_string(cluster.spec.external_servers.as_ref().unwrap()).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use shulker_kube_utils::reconcilers::builder::ResourceBuilder;
+
+    use crate::reconcilers::minecraft_cluster::fixtures::{create_client_mock, TEST_CLUSTER};
+
+    #[test]
+    fn name_contains_cluster_name() {
+        // W
+        let name = super::ExternalServersConfigMapBuilder::name(&TEST_CLUSTER);
+
+        // T
+        assert_eq!(name, "my-cluster-external-servers");
+    }
+
+    #[tokio::test]
+    async fn build_snapshot() {
+        // G
+        let client = create_client_mock();
+        let builder = super::ExternalServersConfigMapBuilder::new(client);
+        let name = super::ExternalServersConfigMapBuilder::name(&TEST_CLUSTER);
+
+        // W
+        let config_map = builder
+            .build(&TEST_CLUSTER, &name, None, None)
+            .await
+            .unwrap();
+
+        // T
+        insta::assert_yaml_snapshot!(config_map);
+    }
+}

--- a/packages/shulker-operator/src/reconcilers/minecraft_cluster/fixtures.rs
+++ b/packages/shulker-operator/src/reconcilers/minecraft_cluster/fixtures.rs
@@ -2,7 +2,9 @@ use http::{Request, Response};
 use kube::client::Body;
 use kube::{core::ObjectMeta, Client};
 use lazy_static::lazy_static;
-use shulker_crds::v1alpha1::minecraft_cluster::{MinecraftCluster, MinecraftClusterSpec};
+use shulker_crds::v1alpha1::minecraft_cluster::{
+    MinecraftCluster, MinecraftClusterExternalServerSpec, MinecraftClusterSpec,
+};
 
 lazy_static! {
     pub static ref TEST_CLUSTER: MinecraftCluster = MinecraftCluster {
@@ -13,7 +15,12 @@ lazy_static! {
         },
         spec: MinecraftClusterSpec {
             network_admins: None,
-            redis: None
+            redis: None,
+            external_servers: Some(vec![MinecraftClusterExternalServerSpec {
+                name: "my-external-server".to_string(),
+                address: "127.0.0.1:25565".to_string(),
+                tags: vec!["game".to_string()]
+            }])
         },
         status: None,
     };

--- a/packages/shulker-operator/src/reconcilers/minecraft_cluster/snapshots/shulker_operator__reconcilers__minecraft_cluster__external_servers_config_map__tests__build_snapshot.snap
+++ b/packages/shulker-operator/src/reconcilers/minecraft_cluster/snapshots/shulker_operator__reconcilers__minecraft_cluster__external_servers_config_map__tests__build_snapshot.snap
@@ -1,0 +1,18 @@
+---
+source: packages/shulker-operator/src/reconcilers/minecraft_cluster/external_servers_config_map.rs
+expression: config_map
+---
+apiVersion: v1
+kind: ConfigMap
+data:
+  external-servers.yaml: "- name: my-external-server\n  address: 127.0.0.1:25565\n  tags:\n  - game\n"
+metadata:
+  labels:
+    app.kubernetes.io/component: proxy
+    app.kubernetes.io/instance: external-servers-my-cluster
+    app.kubernetes.io/managed-by: shulker-operator
+    app.kubernetes.io/name: external-servers
+    app.kubernetes.io/part-of: cluster-my-cluster
+    minecraftcluster.shulkermc.io/name: my-cluster
+  name: my-cluster-external-servers
+  namespace: default

--- a/packages/shulker-operator/src/reconcilers/proxy_fleet/snapshots/shulker_operator__reconcilers__proxy_fleet__fleet__tests__build_snapshot.snap
+++ b/packages/shulker-operator/src/reconcilers/proxy_fleet/snapshots/shulker_operator__reconcilers__proxy_fleet__fleet__tests__build_snapshot.snap
@@ -123,6 +123,9 @@ spec:
                   readOnly: true
                 - mountPath: /tmp
                   name: proxy-tmp
+                - mountPath: /mnt/shulker/external-servers
+                  name: shulker-external-servers
+                  readOnly: true
           initContainers:
             - command:
                 - sh
@@ -171,5 +174,8 @@ spec:
               name: proxy-drain-lock
             - emptyDir: {}
               name: proxy-tmp
+            - configMap:
+                name: my-cluster-external-servers
+              name: shulker-external-servers
       eviction:
         safe: OnUpgrade

--- a/packages/shulker-proxy-agent/build.gradle.kts
+++ b/packages/shulker-proxy-agent/build.gradle.kts
@@ -7,6 +7,10 @@ plugins {
 dependencies {
     commonApi(project(":packages:shulker-proxy-api"))
 
+    // Filesystem
+    commonImplementation(libs.apache.commons.io)
+    commonImplementation(libs.snakeyaml)
+
     // Kubernetes
     commonCompileOnly(libs.kubernetes.client.api)
     commonRuntimeOnly(libs.kubernetes.client)

--- a/packages/shulker-proxy-agent/src/common/kotlin/io/shulkermc/proxyagent/adapters/filesystem/FileSystemAdapter.kt
+++ b/packages/shulker-proxy-agent/src/common/kotlin/io/shulkermc/proxyagent/adapters/filesystem/FileSystemAdapter.kt
@@ -1,9 +1,17 @@
 package io.shulkermc.proxyagent.adapters.filesystem
 
+import java.net.InetSocketAddress
+
 interface FileSystemAdapter {
     fun createDrainLock()
 
     fun createReadinessLock()
 
     fun deleteReadinessLock()
+
+    fun watchExternalServersUpdates(
+        callback: (servers: Map<String, ExternalServer>) -> Unit
+    )
+
+    data class ExternalServer(val name: String, val address: InetSocketAddress, val tags: Set<String>)
 }

--- a/packages/shulker-proxy-agent/src/common/kotlin/io/shulkermc/proxyagent/adapters/filesystem/FileSystemAdapter.kt
+++ b/packages/shulker-proxy-agent/src/common/kotlin/io/shulkermc/proxyagent/adapters/filesystem/FileSystemAdapter.kt
@@ -10,7 +10,7 @@ interface FileSystemAdapter {
     fun deleteReadinessLock()
 
     fun watchExternalServersUpdates(
-        callback: (servers: Map<String, ExternalServer>) -> Unit
+        callback: (servers: Map<String, ExternalServer>) -> Unit,
     )
 
     data class ExternalServer(val name: String, val address: InetSocketAddress, val tags: Set<String>)

--- a/packages/shulker-proxy-agent/src/common/kotlin/io/shulkermc/proxyagent/adapters/filesystem/LocalFileSystemAdapter.kt
+++ b/packages/shulker-proxy-agent/src/common/kotlin/io/shulkermc/proxyagent/adapters/filesystem/LocalFileSystemAdapter.kt
@@ -1,12 +1,24 @@
 package io.shulkermc.proxyagent.adapters.filesystem
 
+import org.apache.commons.io.monitor.FileAlterationListenerAdaptor
+import org.apache.commons.io.monitor.FileAlterationMonitor
+import org.apache.commons.io.monitor.FileAlterationObserver
+import org.yaml.snakeyaml.Yaml
+import java.io.File
+import java.net.InetSocketAddress
 import java.nio.file.Files
 import java.nio.file.Path
-
-private val DRAIN_LOCK_PATH = Path.of("/tmp/drain-lock")
-private val READINESS_LOCK_PATH = Path.of("/tmp/readiness-lock")
+import kotlin.io.path.exists
 
 class LocalFileSystemAdapter : FileSystemAdapter {
+    companion object {
+        private const val EXTERNAL_SERVERS_WATCH_INTERVAL_MS = 10_000L
+
+        private val EXTERNAL_SERVERS_PATH = Path.of("/mnt/shulker/external-servers/external-servers.yaml")
+        private val DRAIN_LOCK_PATH = Path.of("/tmp/drain-lock")
+        private val READINESS_LOCK_PATH = Path.of("/tmp/readiness-lock")
+    }
+
     override fun createDrainLock() {
         if (!Files.exists(DRAIN_LOCK_PATH)) {
             Files.createFile(DRAIN_LOCK_PATH)
@@ -21,5 +33,51 @@ class LocalFileSystemAdapter : FileSystemAdapter {
 
     override fun deleteReadinessLock() {
         Files.deleteIfExists(READINESS_LOCK_PATH)
+    }
+
+    override fun watchExternalServersUpdates(
+        callback: (servers: Map<String, FileSystemAdapter.ExternalServer>) -> Unit
+    ) {
+        val observer = FileAlterationObserver(EXTERNAL_SERVERS_PATH.parent.toFile())
+        observer.addListener(object : FileAlterationListenerAdaptor() {
+            override fun onFileChange(file: File) {
+                callback(parseExternalServersFile(file))
+            }
+
+            override fun onFileDelete(file: File) {
+                callback(emptyMap())
+            }
+        })
+
+        val monitor = FileAlterationMonitor(EXTERNAL_SERVERS_WATCH_INTERVAL_MS, observer)
+        monitor.start()
+
+        if (EXTERNAL_SERVERS_PATH.exists()) {
+            callback(this.parseExternalServersFile(EXTERNAL_SERVERS_PATH.toFile()))
+        }
+    }
+
+    private fun parseExternalServersFile(file: File): Map<String, FileSystemAdapter.ExternalServer> {
+        val yaml = Yaml()
+        val list: List<Map<String, Any>> = yaml.load(file.inputStream())
+
+        @Suppress("UNCHECKED_CAST")
+        return list.associate { entry ->
+            val name = entry["name"] as String
+            val address = entry["address"] as String
+            val tags = entry.getOrDefault("tags", emptyList<String>()) as List<String>
+
+            val addressParts = address.split(":")
+
+            name to FileSystemAdapter.ExternalServer(
+                name,
+                if (addressParts.size == 2) {
+                    InetSocketAddress(addressParts[0], addressParts[1].toInt())
+                } else {
+                    InetSocketAddress(address, 25565)
+                },
+                tags.toSet(),
+            )
+        }
     }
 }

--- a/packages/shulker-proxy-agent/src/common/kotlin/io/shulkermc/proxyagent/adapters/filesystem/LocalFileSystemAdapter.kt
+++ b/packages/shulker-proxy-agent/src/common/kotlin/io/shulkermc/proxyagent/adapters/filesystem/LocalFileSystemAdapter.kt
@@ -36,18 +36,20 @@ class LocalFileSystemAdapter : FileSystemAdapter {
     }
 
     override fun watchExternalServersUpdates(
-        callback: (servers: Map<String, FileSystemAdapter.ExternalServer>) -> Unit
+        callback: (servers: Map<String, FileSystemAdapter.ExternalServer>) -> Unit,
     ) {
         val observer = FileAlterationObserver(EXTERNAL_SERVERS_PATH.parent.toFile())
-        observer.addListener(object : FileAlterationListenerAdaptor() {
-            override fun onFileChange(file: File) {
-                callback(parseExternalServersFile(file))
-            }
+        observer.addListener(
+            object : FileAlterationListenerAdaptor() {
+                override fun onFileChange(file: File) {
+                    callback(parseExternalServersFile(file))
+                }
 
-            override fun onFileDelete(file: File) {
-                callback(emptyMap())
-            }
-        })
+                override fun onFileDelete(file: File) {
+                    callback(emptyMap())
+                }
+            },
+        )
 
         val monitor = FileAlterationMonitor(EXTERNAL_SERVERS_WATCH_INTERVAL_MS, observer)
         monitor.start()
@@ -69,15 +71,16 @@ class LocalFileSystemAdapter : FileSystemAdapter {
 
             val addressParts = address.split(":")
 
-            name to FileSystemAdapter.ExternalServer(
-                name,
-                if (addressParts.size == 2) {
-                    InetSocketAddress(addressParts[0], addressParts[1].toInt())
-                } else {
-                    InetSocketAddress(address, 25565)
-                },
-                tags.toSet(),
-            )
+            name to
+                FileSystemAdapter.ExternalServer(
+                    name,
+                    if (addressParts.size == 2) {
+                        InetSocketAddress(addressParts[0], addressParts[1].toInt())
+                    } else {
+                        InetSocketAddress(address, 25565)
+                    },
+                    tags.toSet(),
+                )
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,6 +10,7 @@ dependencyResolutionManagement {
             library("adventure-api", "net.kyori:adventure-api:4.17.0")
             library("adventure-platform-bungeecord", "net.kyori:adventure-platform-bungeecord:4.3.4")
             library("annotations-api", "org.apache.tomcat:annotations-api:6.0.53")
+            library("apache-commons-io", "commons-io:commons-io:2.16.1")
             library("bungeecord-api", "net.md-5:bungeecord-api:1.21-R0.1-SNAPSHOT")
             library("folia-api", "dev.folia:folia-api:1.20.6-R0.1-SNAPSHOT")
             library("guava", "com.google.guava:guava:33.3.0-jre")
@@ -23,6 +24,7 @@ dependencyResolutionManagement {
             library("kubernetes-client-api", "io.fabric8", "kubernetes-client-api").versionRef("kubernetes-client")
             library("kubernetes-client-http", "io.fabric8", "kubernetes-httpclient-okhttp").versionRef("kubernetes-client")
             library("protobuf", "com.google.protobuf:protobuf-java:3.25.4")
+            library("snakeyaml", "org.yaml:snakeyaml:2.2")
             library("velocity-api", "com.velocitypowered:velocity-api:3.3.0-SNAPSHOT")
 
             plugin("buildconfig", "com.github.gmazzo.buildconfig").version("5.4.0")


### PR DESCRIPTION
The external servers can be provided by filling the `externalServers` field in the `MinecraftCluster`:

```yaml
apiVersion: shulkermc.io/v1alpha1
kind: MinecraftCluster
metadata:
  name: getting-started
spec:
  externalServers:
    - name: external
      address: 127.0.0.1
      tags:
        - my_tag
    - name: external2
      address: 127.0.0.2

```

Closes #630 