### PR TITLE
feat: add Minestom to `bug_report.yml`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,6 +29,7 @@ body:
         - Proxy Agent (Velocity)
         - Server API
         - Server Agent (Paper)
+        - Server Agent (Minestom)
 
   - type: input
     id: version


### PR DESCRIPTION
Since there is now an offical Minestom server agent it should be added into the list of chooseable components inside the form.

Orignally noted in #650:

> Also you should add a slection for the Minestom agent inside the components category of this form.