### PR TITLE
feat(shulker-server-agent): handle graceful shutdown for Minestom

### DIFF
--- a/examples/custom-server-jar/minecraftserver-minestom.yaml
+++ b/examples/custom-server-jar/minecraftserver-minestom.yaml
@@ -1,7 +1,7 @@
 apiVersion: shulkermc.io/v1alpha1
 kind: MinecraftServerFleet
 metadata:
-  name: lobby
+  name: minestom
 spec:
   clusterRef:
     name: custom-server-jar
@@ -10,11 +10,13 @@ spec:
     spec:
       clusterRef:
         name: custom-server-jar
-      tags:
-        - lobby
       version:
         channel: Paper
         name: "1.21.4"
         customJar:
-          url: https://api.infernalsuite.com/v1/projects/asp/5118810e-2397-48f2-a725-89372c6d3756/download/e2eab933-7e5c-4a1f-8776-89a6624283a0
+          url: https://url-to-minestom/server.jar
       config: {}
+      podOverrides:
+        env:
+          - name: EXEC_DIRECTLY
+            value: "true"

--- a/examples/getting-started/minecraftserver.yaml
+++ b/examples/getting-started/minecraftserver.yaml
@@ -14,5 +14,5 @@ spec:
         - lobby
       version:
         channel: Paper
-        name: "1.21.1"
+        name: "1.21.4"
       config: {}

--- a/examples/mounting-volumes/minecraftserver.yaml
+++ b/examples/mounting-volumes/minecraftserver.yaml
@@ -14,7 +14,7 @@ spec:
         - lobby
       version:
         channel: Paper
-        name: "1.21.1"
+        name: "1.21.4"
       config: {}
       podOverrides:
         volumeMounts:

--- a/examples/with-custom-configuration/minecraftserver.yaml
+++ b/examples/with-custom-configuration/minecraftserver.yaml
@@ -14,7 +14,7 @@ spec:
         - lobby
       version:
         channel: Paper
-        name: "1.21.1"
+        name: "1.21.4"
       config:
         world:
           url: https://example.com/my-world.tar.gz

--- a/packages/shulker-addon-matchmaking/Dockerfile
+++ b/packages/shulker-addon-matchmaking/Dockerfile
@@ -34,8 +34,8 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 
 COPY . .
 
-RUN pnpm exec nx build shulker-addon-matchmaking -- --target=$(cat /.rust-triple) \
-  && cp dist/rust/$(cat /.rust-triple)/release/shulker-addon-matchmaking-director dist/rust/release/shulker-addon-matchmaking-director \
+RUN cd packages/shulker-addon-matchmaking && cargo build --release --bins --target=$(cat /.rust-triple)
+RUN cp dist/rust/$(cat /.rust-triple)/release/shulker-addon-matchmaking-director dist/rust/release/shulker-addon-matchmaking-director \
   && cp dist/rust/$(cat /.rust-triple)/release/shulker-addon-matchmaking-mmf dist/rust/release/shulker-addon-matchmaking-mmf
 
 FROM gcr.io/distroless/cc-debian12:nonroot

--- a/packages/shulker-operator/Dockerfile
+++ b/packages/shulker-operator/Dockerfile
@@ -34,8 +34,8 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 
 COPY . .
 
-RUN pnpm exec nx build shulker-operator -- --target=$(cat /.rust-triple) \
-  && cp dist/rust/$(cat /.rust-triple)/release/shulker-operator dist/rust/release/shulker-operator
+RUN cd packages/shulker-operator && cargo build --release --bins --target=$(cat /.rust-triple)
+RUN cp dist/rust/$(cat /.rust-triple)/release/shulker-operator dist/rust/release/shulker-operator
 
 FROM gcr.io/distroless/cc-debian12:nonroot
 COPY --from=builder /build/dist/rust/release/shulker-operator /

--- a/packages/shulker-server-agent/src/minestom/kotlin/io/shulkermc/serveragent/minestom/ServerInterfaceMinestom.kt
+++ b/packages/shulker-server-agent/src/minestom/kotlin/io/shulkermc/serveragent/minestom/ServerInterfaceMinestom.kt
@@ -9,7 +9,6 @@ import net.minestom.server.event.EventNode
 import net.minestom.server.event.player.AsyncPlayerConfigurationEvent
 import net.minestom.server.event.player.PlayerDisconnectEvent
 import net.minestom.server.event.player.PlayerSpawnEvent
-import net.minestom.server.permission.Permission
 import net.minestom.server.timer.Task
 import net.minestom.server.timer.TaskSchedule
 import java.time.Duration
@@ -27,7 +26,6 @@ class ServerInterfaceMinestom : ServerInterface {
         this.eventNode.addListener(AsyncPlayerConfigurationEvent::class.java) { event ->
             if (playerIds.contains(event.player.uuid)) {
                 event.player.permissionLevel = ADMIN_PERMISSION_LEVEL
-                event.player.addPermission(Permission("*"))
             }
         }
     }

--- a/packages/shulker-server-agent/src/minestom/kotlin/io/shulkermc/serveragent/minestom/ShulkerServerAgentMinestom.kt
+++ b/packages/shulker-server-agent/src/minestom/kotlin/io/shulkermc/serveragent/minestom/ShulkerServerAgentMinestom.kt
@@ -7,6 +7,7 @@ import net.minestom.server.MinecraftServer
 import net.minestom.server.extras.bungee.BungeeCordProxy
 import net.minestom.server.extras.velocity.VelocityProxy
 import java.util.logging.Logger
+import kotlin.system.exitProcess
 
 @Suppress("unused")
 class ShulkerServerAgentMinestom private constructor(private val logger: Logger) {
@@ -42,6 +43,11 @@ class ShulkerServerAgentMinestom private constructor(private val logger: Logger)
     private val agent = ShulkerServerAgentCommon(ServerInterfaceMinestom(), this.logger)
 
     private fun onServerInitialization() {
+        if (System.getenv("EXEC_DIRECTLY") != "true") {
+            this.logger.severe("Please set the environment variable EXEC_DIRECTLY to true. It is required so the Minestom server can be shutdown properly.")
+            exitProcess(1)
+        }
+
         this.server = MinecraftServer.init()
 
         this.logger.info("Loading configuration files")
@@ -57,6 +63,13 @@ class ShulkerServerAgentMinestom private constructor(private val logger: Logger)
         }
 
         this.agent.onServerInitialization()
+
+        Runtime.getRuntime().addShutdownHook(object : Thread() {
+            override fun run() {
+                logger.info("Shutdown signal received, stopping cleanly")
+                MinecraftServer.stopCleanly()
+            }
+        })
     }
 
     private fun onServerReady() {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,7 +23,7 @@ dependencyResolutionManagement {
             library("kubernetes-client", "io.fabric8", "kubernetes-client").versionRef("kubernetes-client")
             library("kubernetes-client-api", "io.fabric8", "kubernetes-client-api").versionRef("kubernetes-client")
             library("kubernetes-client-http", "io.fabric8", "kubernetes-httpclient-okhttp").versionRef("kubernetes-client")
-            library("minestom", "net.minestom:minestom-snapshots:a521c4e7cd")
+            library("minestom", "net.minestom:minestom-snapshots:1_21_4-7599413490")
             library("protobuf", "com.google.protobuf:protobuf-java:4.31.0")
             library("snakeyaml", "org.yaml:snakeyaml:2.4")
             library("velocity-api", "com.velocitypowered:velocity-api:3.3.0-SNAPSHOT")


### PR DESCRIPTION
- Registered a shutdown hook so the stopCleanly method is called
- Crash the server if the `EXEC_DIRECTLY` environment variable is missing, thus meaning that itzg's server wrapper is applied (which traps the stop signal)